### PR TITLE
fix: add base_url config for reverse proxy auth

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type AuthConfig struct {
 type Config struct {
 	Port             int
 	Host             string
+	BaseURL          string `mapstructure:"base_url"`
 	WatchPath        string
 	LogLevel         string
 	RespectGitignore bool
@@ -37,6 +38,7 @@ func Load(cfgFile string) (*Config, error) {
 	v.SetDefault("respectgitignore", true)
 	v.SetDefault("theme", "iceberg-dark")
 	v.SetDefault("recentfilescount", 5)
+	v.SetDefault("base_url", "")
 	v.SetDefault("defaultfile", "")
 	v.SetDefault("ignorepatterns", []string{
 		".git",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,7 +66,11 @@ func NewServer(cfg *config.Config) *Server {
 			panic(fmt.Sprintf("failed to create session manager: %v", err))
 		}
 
-		serverURL = fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
+		if cfg.BaseURL != "" {
+			serverURL = cfg.BaseURL
+		} else {
+			serverURL = fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
+		}
 		handler = auth.Middleware(sm)(handler)
 		logger.Log.Info("auth enabled", "allowed_pubkeys", len(allowedPubkeys))
 	}


### PR DESCRIPTION
When behind a reverse proxy, the NIP-98 auth verify URL was constructed from the internal host:port (e.g. `http://127.0.0.1:8090`) instead of the public URL. This caused CORS errors when the browser tried to POST the signed event to the internal address.

**Fix:** Added `base_url` config option that overrides the computed server URL for auth flows.

```toml
base_url = "https://stigmergic.nostr.xyz"
```

Closes #2 (partially — this is the deployment fix needed for exposed instances).